### PR TITLE
Fix missing tiktoken dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ This repository provides a basic Poetry environment for developing AGENTIC AI pr
    ```
 
    This installs all required packages, including the `langchain-community`
-   extension used for document loaders.
+   extension used for document loaders and the `tiktoken` package needed for
+   OpenAI embeddings.
 
 3. Activate the virtual environment:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ langchain = "*"
 langchain-community = "*"
 faiss-cpu = "*"
 pypdf = "*"
+tiktoken = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"


### PR DESCRIPTION
## Summary
- include `tiktoken` in the Poetry dependencies
- document that Poetry install will also install `tiktoken`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b17692cc8325853fe0165ef7fd8e