### PR TITLE
Add Kt/V prediction utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ You can now add your own AGENTIC AI code inside the `src/` directory.
 The `rag_app.py` module provides a basic retrieval-augmented generation (RAG) demo.
 It loads a PDF, chunks the content, creates embeddings with OpenAI's
 `text-embedding-3-small` model and stores them in a FAISS index. A simple
-Streamlit UI lets you ask questions about the uploaded document.
+Streamlit UI lets you ask questions about the uploaded document. If the PDF
+contains laboratory values for **BUN** and **Creatinine**, you can press the
+sidebar "Predict Kt/V" button to compute a simple estimate using those values.
+When the labs are not found directly in the text, and an OpenAI API key is
+available, the app falls back to a small agent that asks ChatGPT to extract the
+values.
 
 Run the demo with:
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ It loads a PDF, chunks the content, creates embeddings with OpenAI's
 `text-embedding-3-small` model and stores them in a FAISS index. A simple
 Streamlit UI lets you ask questions about the uploaded document. If the PDF
 contains laboratory values for **BUN** and **Creatinine**, you can press the
-sidebar "Predict Kt/V" button to compute a simple estimate using those values.
-When the labs are not found directly in the text, and an OpenAI API key is
-available, the app falls back to a small agent that asks ChatGPT to extract the
-values.
+sidebar "Predict Kt/V" button or simply ask for a Kt/V prediction in the chat
+itself. The app then calls a tool that multiplies the lab values. When the labs
+are not found directly in the text, and an OpenAI API key is available, the app
+falls back to a small agent that asks ChatGPT to extract the values.
 
 Run the demo with:
 

--- a/src/vasagent/ktv.py
+++ b/src/vasagent/ktv.py
@@ -1,0 +1,5 @@
+"""Utilities for Kt/V prediction."""
+
+def predict_ktv(BUN: float, Creatinine: float) -> float:
+    """Return the product of BUN and Creatinine as a simple Kt/V estimate."""
+    return BUN * Creatinine

--- a/src/vasagent/ktv.py
+++ b/src/vasagent/ktv.py
@@ -38,3 +38,25 @@ def extract_lab_values(text: str) -> Tuple[Optional[float], Optional[float]]:
             pass
 
     return bun, creatinine
+
+
+def predict_ktv_from_text(text: str, api_key: str | None = None) -> float:
+    """Return predicted Kt/V from free-form report text.
+
+    The function first attempts to parse BUN and Creatinine values using
+    :func:`extract_lab_values`. If either value is missing and ``api_key`` is
+    provided, it falls back to :class:`~vasagent.mcp_agent.MCPAgent` which uses
+    ChatGPT to identify the lab values.
+    """
+
+    bun, creatinine = extract_lab_values(text)
+    if bun is not None and creatinine is not None:
+        return predict_ktv(bun, creatinine)
+
+    if api_key is None:
+        raise ValueError("BUN and Creatinine not found in text")
+
+    from vasagent.mcp_agent import MCPAgent
+
+    agent = MCPAgent(api_key=api_key)
+    return agent.predict(text)

--- a/src/vasagent/ktv.py
+++ b/src/vasagent/ktv.py
@@ -1,5 +1,40 @@
 """Utilities for Kt/V prediction."""
 
-def predict_ktv(BUN: float, Creatinine: float) -> float:
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+
+def predict_ktv(bun: float, creatinine: float) -> float:
     """Return the product of BUN and Creatinine as a simple Kt/V estimate."""
-    return BUN * Creatinine
+
+    return bun * creatinine
+
+
+def extract_lab_values(text: str) -> Tuple[Optional[float], Optional[float]]:
+    """Return BUN and Creatinine values parsed from ``text``.
+
+    The function searches for patterns like ``"BUN: 12"`` or
+    ``"Creatinine 1.2"``. If either value is missing, ``None`` is returned
+    in its place.
+    """
+
+    bun = None
+    creatinine = None
+
+    bun_match = re.search(r"BUN[:\s]+([\d.]+)", text, flags=re.IGNORECASE)
+    if bun_match:
+        try:
+            bun = float(bun_match.group(1))
+        except ValueError:  # pragma: no cover - regex ensures numeric
+            pass
+
+    cre_match = re.search(r"Creatinine[:\s]+([\d.]+)", text, flags=re.IGNORECASE)
+    if cre_match:
+        try:
+            creatinine = float(cre_match.group(1))
+        except ValueError:  # pragma: no cover
+            pass
+
+    return bun, creatinine

--- a/src/vasagent/main.py
+++ b/src/vasagent/main.py
@@ -21,11 +21,15 @@ def main() -> None:
         with open(args.report, "r", encoding="utf-8") as f:
             report = json.load(f)
         if args.predict:
-            if "BUN" in report and "Creatinine" in report:
-                result = predict_ktv(report["BUN"], report["Creatinine"])
+            bun = report.get("BUN")
+            creatinine = report.get("Creatinine")
+            if bun is not None and creatinine is not None:
+                result = predict_ktv(bun, creatinine)
                 print(f"Predicted Kt/V: {result}")
             else:
-                print("Prediction requested but BUN and Creatinine not found in report.")
+                print(
+                    "Prediction requested but BUN and Creatinine not found in report."
+                )
     else:
         if args.predict:
             print("No report provided.")

--- a/src/vasagent/main.py
+++ b/src/vasagent/main.py
@@ -1,7 +1,35 @@
-from . import hello
+import argparse
+import json
 
-def main():
+from vasagent import hello
+from vasagent.ktv import predict_ktv
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process a lab report.")
+    parser.add_argument("report", nargs="?", help="Path to JSON report")
+    parser.add_argument(
+        "--predict",
+        action="store_true",
+        help="Predict Kt/V if BUN and Creatinine are present in the report",
+    )
+    args = parser.parse_args()
+
     print(hello())
+
+    if args.report:
+        with open(args.report, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        if args.predict:
+            if "BUN" in report and "Creatinine" in report:
+                result = predict_ktv(report["BUN"], report["Creatinine"])
+                print(f"Predicted Kt/V: {result}")
+            else:
+                print("Prediction requested but BUN and Creatinine not found in report.")
+    else:
+        if args.predict:
+            print("No report provided.")
+
 
 if __name__ == "__main__":
     main()

--- a/src/vasagent/mcp_agent.py
+++ b/src/vasagent/mcp_agent.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai may not be installed
+    OpenAI = None  # type: ignore
+
+from vasagent.ktv import extract_lab_values, predict_ktv
+
+
+class MCPAgent:
+    """Agentic helper that leverages ChatGPT to predict Kt/V."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        if OpenAI is None:
+            raise ImportError("openai package is required for MCPAgent")
+        self.client = OpenAI(api_key=api_key)
+
+    def predict(self, text: str) -> float:
+        """Return predicted Kt/V for ``text`` using ChatGPT for extraction."""
+        bun, creatinine = extract_lab_values(text)
+        if bun is None or creatinine is None:
+            messages = [
+                {
+                    "role": "system",
+                    "content": (
+                        "Extract BUN and Creatinine values from the report. "
+                        "Respond strictly as 'BUN:<value> Creatinine:<value>'."
+                    ),
+                },
+                {"role": "user", "content": text},
+            ]
+            response = self.client.chat.completions.create(
+                model="gpt-4o-mini", messages=messages
+            )
+            reply = response.choices[0].message.content or ""
+            bun2, creatinine2 = extract_lab_values(reply)
+            bun = bun if bun is not None else bun2
+            creatinine = creatinine if creatinine is not None else creatinine2
+
+        if bun is None or creatinine is None:
+            raise ValueError("BUN or Creatinine could not be determined")
+
+        return predict_ktv(bun, creatinine)

--- a/src/vasagent/qa.py
+++ b/src/vasagent/qa.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Helper for processing user queries in the RAG app."""
+
+from vasagent.ktv import predict_ktv_from_text
+
+
+def answer_query(query: str, full_text: str, qa_chain, api_key: str | None = None) -> str:
+    """Return an answer to ``query``.
+
+    If the question appears to request a Kt/V prediction, the function uses
+    :func:`predict_ktv_from_text` to compute the value from ``full_text``.
+    Otherwise it calls ``qa_chain.invoke``.
+    """
+
+    if "ktv" in query.lower():
+        try:
+            result = predict_ktv_from_text(full_text, api_key=api_key)
+            return f"Predicted Kt/V: {result}"
+        except Exception as e:  # pragma: no cover - pass through errors
+            return f"Could not predict Kt/V: {e}"
+
+    output = qa_chain.invoke({"input": query})
+    return output.get("answer", "")

--- a/src/vasagent/rag_app.py
+++ b/src/vasagent/rag_app.py
@@ -15,6 +15,8 @@ from langchain.chains.combine_documents import create_stuff_documents_chain
 from langchain.prompts import ChatPromptTemplate
 from langchain.chat_models import ChatOpenAI
 
+from vasagent.ktv import extract_lab_values, predict_ktv
+
 
 load_dotenv()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -61,6 +63,8 @@ if uploaded_file:
 
     loader = PyPDFLoader(tmp_path)
     docs = loader.load()
+    full_text = " ".join(d.page_content for d in docs)
+    bun, creatinine = extract_lab_values(full_text)
 
     splitter = RecursiveCharacterTextSplitter(chunk_size=1500, chunk_overlap=200)
     chunks = splitter.split_documents(docs)
@@ -80,9 +84,18 @@ Question: {input}
 """
     )
 
-    document_chain = create_stuff_documents_chain(ChatOpenAI(api_key=OPENAI_API_KEY), prompt)
+    document_chain = create_stuff_documents_chain(
+        ChatOpenAI(api_key=OPENAI_API_KEY), prompt
+    )
     retriever = vectors.as_retriever()
     qa_chain = create_retrieval_chain(retriever, document_chain)
+
+    if st.sidebar.button("Predict Kt/V"):
+        if bun is not None and creatinine is not None:
+            result = predict_ktv(bun, creatinine)
+            st.sidebar.write(f"Predicted Kt/V: {result}")
+        else:
+            st.sidebar.write("BUN and Creatinine not found in report.")
 
     user_query = st.chat_input("Ask a question:")
     if user_query:

--- a/src/vasagent/rag_app.py
+++ b/src/vasagent/rag_app.py
@@ -16,6 +16,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain.chat_models import ChatOpenAI
 
 from vasagent.ktv import predict_ktv_from_text
+from vasagent.qa import answer_query
 
 
 load_dotenv()
@@ -98,7 +99,7 @@ Question: {input}
 
     user_query = st.chat_input("Ask a question:")
     if user_query:
-        result = qa_chain.invoke({"input": user_query})
-        st.write(result.get("answer"))
+        response = answer_query(user_query, full_text, qa_chain, api_key=OPENAI_API_KEY)
+        st.write(response)
 else:
     st.write("Please upload a PDF to begin.")

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -6,11 +6,16 @@ from pathlib import Path
 
 import pytest
 
-from vasagent.ktv import predict_ktv
+from vasagent.ktv import extract_lab_values, predict_ktv
 
 
 def test_predict_ktv():
     assert predict_ktv(10, 2) == 20
+
+
+def test_extract_lab_values():
+    text = "BUN: 8 Creatinine: 1.2"
+    assert extract_lab_values(text) == (8.0, 1.2)
 
 
 def test_main_predict(tmp_path: Path):

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from vasagent.ktv import extract_lab_values, predict_ktv
+from vasagent.ktv import (
+    extract_lab_values,
+    predict_ktv,
+    predict_ktv_from_text,
+)
 
 
 def test_predict_ktv():
@@ -16,6 +20,11 @@ def test_predict_ktv():
 def test_extract_lab_values():
     text = "BUN: 8 Creatinine: 1.2"
     assert extract_lab_values(text) == (8.0, 1.2)
+
+
+def test_predict_ktv_from_text_direct():
+    text = "BUN: 3 Creatinine: 2"
+    assert predict_ktv_from_text(text) == 6
 
 
 def test_main_predict(tmp_path: Path):
@@ -64,4 +73,11 @@ def test_mcp_agent(monkeypatch):
     monkeypatch.setattr(mcp_agent, "OpenAI", DummyOpenAI)
     agent = MCPAgent(api_key="test")
     result = agent.predict("Sample report")
+    assert result == 4.0
+
+
+def test_predict_ktv_from_text_agent(monkeypatch):
+    monkeypatch.setattr(mcp_agent, "OpenAI", DummyOpenAI)
+    monkeypatch.setattr("vasagent.mcp_agent.MCPAgent", MCPAgent)
+    result = predict_ktv_from_text("no labs", api_key="key")
     assert result == 4.0

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,31 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vasagent.ktv import predict_ktv
+
+
+def test_predict_ktv():
+    assert predict_ktv(10, 2) == 20
+
+
+def test_main_predict(tmp_path: Path):
+    report = {"BUN": 5, "Creatinine": 3}
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps(report))
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+    result = subprocess.run(
+        [sys.executable, "-m", "vasagent.main", str(report_path), "--predict"],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    assert "Predicted Kt/V: 15" in result.stdout


### PR DESCRIPTION
## Summary
- provide `predict_ktv` function for multiplying BUN and Creatinine
- extend `main.py` with CLI support to load a JSON report and optionally predict Kt/V
- add tests for the new function and CLI behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b72ec7308325af897681bf422751